### PR TITLE
add support for kube 1.8 and CRDs

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -59,6 +59,7 @@ cluster_objects=(
     persistentvolumes\
     storageclasses\
     thirdpartyresources\
+    customresourcedefinitions\
     )
 
 # setup a global "spaces" variable that lists every namesapce
@@ -85,9 +86,13 @@ init_cleanup_handler() {
 }
 
 backup_cluster_objects() {
+    echo "Backing up cluster-wide resources"
     for i in "${cluster_objects[@]}" ; do
+        echo "   $i"
         mkdir -p "${TMPDIR}/${backup_dir}"
-        kubectl get "$i" -oyaml > "${TMPDIR}/${backup_dir}/${i}.yaml" 2> /dev/null
+        if ! kubectl get "$i" -oyaml > "${TMPDIR}/${backup_dir}/${i}.yaml"; then
+            echo "WARNING: failed to backup cluster-wide resource type '$i', continuing with backup of remaining resources"
+        fi
     done
 }
 


### PR DESCRIPTION
The backup was silenty failing on kube 1.8 clusters due to lack of TPRs.
This PR adds support for CRDs and adds additional logging so that the
failure is easier to debug in the future.